### PR TITLE
Fix for WHMCS 8.2 compatibility

### DIFF
--- a/modules/servers/solusvmpro/lib/SolusVM.php
+++ b/modules/servers/solusvmpro/lib/SolusVM.php
@@ -1050,7 +1050,7 @@ class SolusVM {
     public static function loadLang( $lang = null ) {
         global $_LANG, $CONFIG;
 
-        $langDir                = __DIR__ . '/../lang/';
+        $langDir                = ROOTDIR . '/modules/servers/solusvmpro/lang/';
         $availableLangsFullPath = glob( $langDir . '*.php' );
         $availableLangs         = array();
         foreach ( $availableLangsFullPath as $availableLang ) {


### PR DESCRIPTION
For some reason after updating from WHMCS 8.1.3 to 8.2, `__DIR__` will not work here in the context of WHMCS cron. It returns the file path for the script that called it, resulting in errors like:

```
PHP Fatal error:  require_once(): Failed opening required '/path/to/whmcs/vendor/whmcs/whmcs-foundation/lib/Log/../lang/english.php' (include_path='.:/opt/plesk/php/7.4/share/pear') in /path/to/whmcs/vendor/whmcs/whmcs-foundation/lib/Log/ErrorLog.php on line 1145
```

This change repairs that by using the WHMCS global 'ROOTDIR' rather than __DIR__